### PR TITLE
Remove the need for saying find

### DIFF
--- a/slack-faq-bot/commands/find.rb
+++ b/slack-faq-bot/commands/find.rb
@@ -13,7 +13,7 @@ module SlackFaqBot
 
   module Commands
     class Find < SlackRubyBot::Commands::Base
-      match(/(find) (?<query>.+)/i) do |client, data, match|
+      match(/^(faqbot)\ (?!.*store)(?<query>.+)/i) do |client, data, match|
         SlackFaqBot.find(query: match[:query], client: client, data: data)
       end
     end

--- a/slack-faq-bot/commands/store.rb
+++ b/slack-faq-bot/commands/store.rb
@@ -14,7 +14,7 @@ module SlackFaqBot
 
   module Commands
     class Find < SlackRubyBot::Commands::Base
-      match(/(store) q\:(?<question>.+)a\:(?<answer>.+)/i) do |client, data, match|
+      match(/(faqbot store) q\:(?<question>.+)a\:(?<answer>.+)/i) do |client, data, match|
         SlackFaqBot.store(
           question: match[:question], answer: match[:answer],
           client: client, data: data


### PR DESCRIPTION
This means you can just say `faqbot query` instead of `faqbot find query`